### PR TITLE
Fix importing images and labels with filenames with multiple dots

### DIFF
--- a/src/utils/FileUtil.ts
+++ b/src/utils/FileUtil.ts
@@ -42,10 +42,19 @@ export class FileUtil {
 
     public static extractFileExtension(name: string): string | null {
         const parts = name.split(".");
-        return parts.length > 1 ? parts[1] : null;
+        //return parts.length > 1 ? parts[1] : null;
+        // fix for files with multiple dots
+        return parts.length > 1 ? parts[parts.length - 1] : null;
     }
 
     public static extractFileName(name: string): string | null {
-        return name.split(".")[0];
+        //return name.split(".")[0];
+        // fix for files with multiple dots
+        var splitPath = name.split(".");
+        var fName = "";
+        for(const idx of Array(splitPath.length - 1).keys()){
+            fName = fName + "." + splitPath[idx];
+        }
+        return fName;
     }
 }

--- a/src/utils/FileUtil.ts
+++ b/src/utils/FileUtil.ts
@@ -42,14 +42,10 @@ export class FileUtil {
 
     public static extractFileExtension(name: string): string | null {
         const parts = name.split(".");
-        //return parts.length > 1 ? parts[1] : null;
-        // fix for files with multiple dots
         return parts.length > 1 ? parts[parts.length - 1] : null;
     }
 
     public static extractFileName(name: string): string | null {
-        //return name.split(".")[0];
-        // fix for files with multiple dots
         var splitPath = name.split(".");
         var fName = "";
         for(const idx of Array(splitPath.length - 1).keys()){

--- a/src/utils/FileUtil.ts
+++ b/src/utils/FileUtil.ts
@@ -53,7 +53,8 @@ export class FileUtil {
         var splitPath = name.split(".");
         var fName = "";
         for(const idx of Array(splitPath.length - 1).keys()){
-            fName = fName + "." + splitPath[idx];
+            if(fName == "") fName += splitPath[idx];
+            else fName += "." + splitPath[idx];
         }
         return fName;
     }

--- a/src/utils/__tests__/FileUtil.test.ts
+++ b/src/utils/__tests__/FileUtil.test.ts
@@ -13,6 +13,18 @@ describe('FileUtil extractFileExtension method', () => {
         expect(result).toEqual(expectedResult);
     });
 
+    it('should return file extension even with multiple dots', () => {
+        // given
+        const name: string = "custom.file-name.12.labels.txt";
+
+        // when
+        const result = FileUtil.extractFileExtension(name);
+
+        // then
+        const expectedResult = "txt";
+        expect(result).toEqual(expectedResult);
+    });
+
     it('should return null', () => {
         // given
         const name: string = "labels";
@@ -36,6 +48,18 @@ describe('FileUtil extractFileName method', () => {
 
         // then
         const expectedResult = "labels";
+        expect(result).toEqual(expectedResult);
+    });
+
+    it('should return file name even with multiple dots', () => {
+        // given
+        const name: string = "custom.file-name.12.labels.txt";
+
+        // when
+        const result = FileUtil.extractFileName(name);
+
+        // then
+        const expectedResult = "custom.file-name.12.labels";
         expect(result).toEqual(expectedResult);
     });
 });


### PR DESCRIPTION
### Pre-flight checklist

- [X] Unit tests for all non-trivial changes
- [X] Tested locally
- [ ] Updated wiki no need

Labels and filenames with multiple dots now are working as intended, fix #140.

