### PR TITLE
fix/dockerfile can be built with current develop branch

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11.10-slim
+FROM node:12.10-slim
 
 RUN apt-get update && apt-get -y install git && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I updated the base image to node 12. With node 11, it does not build.
The container builds, and tests are successful in the container

![image](https://user-images.githubusercontent.com/1220912/131511084-4e370a60-7958-4363-a1a6-cdb03b3017e9.png)


### Pre-flight checklist

- [X] Unit tests for all non-trivial changes
- [X] Tested locally
- [] Updated wiki
