### PR TITLE
Change 'Unspecified' to '0' for TFLite Model Maker compatibility

### DIFF
--- a/src/logic/export/RectLabelsExporter.ts
+++ b/src/logic/export/RectLabelsExporter.ts
@@ -129,7 +129,7 @@ export class RectLabelsExporter {
             const labelFields = !!labelName ? [
                 `\t<object>`,
                 `\t\t<name>${labelName.name}</name>`,
-                `\t\t<pose>0</pose>`,
+                `\t\t<pose>Unspecified</pose>`,
                 `\t\t<truncated>0</truncated>`,
                 `\t\t<difficult>0</difficult>`,
                 `\t\t<bndbox>`,


### PR DESCRIPTION
TFLite Model Maker[1] throws a ValueError when importing PASCAL VOC data made from Make Sense because it expects certain values ("truncated" and "difficult") to be integers[2]. This PR changes those default values to zero so Model Maker will accept the XML, which seems to be the accepted pattern, as demonstrated in the VOC test datasets[3].

[1] https://www.tensorflow.org/lite/api_docs/python/tflite_model_maker/object_detector/DataLoader?hl=en#from_pascal_voc
[2] https://github.com/google/automl/blob/1.2/efficientdet/dataset/create_pascal_tfrecord.py#L170-L179
[3] http://host.robots.ox.ac.uk/pascal/VOC/voc2007/index.html#testdata

### Pre-flight checklist

- [ ] Unit tests for all non-trivial changes
- [x] Tested locally
- [ ] Updated wiki
