### PR TITLE
fix/329 shortcut to toogle all labels visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ docker logs make-sense
 | Zoom out                           | Editor   | <kbd>⌥</kbd> + <kbd>-</kbd> | <kbd>Ctrl</kbd> + <kbd>-</kbd> |
 | Move image                         | Editor   | <kbd>Up</kbd> / <kbd>Down</kbd> / <kbd>Left</kbd> / <kbd>Right</kbd> | <kbd>Up</kbd> / <kbd>Down</kbd> / <kbd>Left</kbd> / <kbd>Right</kbd> |
 | Select Label                       | Editor   | <kbd>⌥</kbd> + <kbd>0-9</kbd> | <kbd>Ctrl</kbd> + <kbd>0-9</kbd> |
+| Show/Hide All Labels               | Editor   | <kbd>h</kbd>      | <kbd>h</kbd>
 | Exit popup                         | Popup    | <kbd>Escape</kbd> | <kbd>Escape</kbd> |
 
 **Table 1.** Supported keyboard shortcuts

--- a/src/logic/actions/ImageActions.ts
+++ b/src/logic/actions/ImageActions.ts
@@ -17,6 +17,7 @@ import {
   LabelRect,
 } from "../../store/labels/types";
 import { LabelStatus } from "../../data/enums/LabelStatus";
+import { LabelActions } from "./LabelActions";
 import { remove } from "lodash";
 
 export class ImageActions {
@@ -148,5 +149,10 @@ export class ImageActions {
     }
 
     return newImageData;
+  }
+
+  public static toggleAllLabelsVisibility(): void {
+    const imageData: ImageData = LabelsSelector.getActiveImageData();
+    LabelActions.toggleAllLabelsVisibility(imageData.id);
   }
 }

--- a/src/logic/actions/ImageActions.ts
+++ b/src/logic/actions/ImageActions.ts
@@ -61,6 +61,13 @@ export class ImageActions {
     store.dispatch(updateActiveLabelNameId(labelNames[1].id));
   }
 
+  public static toggleAllLabelsVisibility(): void {
+    const imageData: ImageData = LabelsSelector.getActiveImageData();
+    const newToggleValue = imageData.allLabelsVisibilityToggle ? !imageData.allLabelsVisibilityToggle : false;
+    
+    LabelActions.setAllLabelsVisibility(imageData.id, newToggleValue);
+  }
+
   private static mapNewImageData(
     imageData: ImageData,
     labelIndex: number
@@ -149,12 +156,5 @@ export class ImageActions {
     }
 
     return newImageData;
-  }
-
-  public static toggleAllLabelsVisibility(): void {
-    const imageData: ImageData = LabelsSelector.getActiveImageData();
-    const newToggleValue = imageData.allLabelsVisibilityToggle ? !imageData.allLabelsVisibilityToggle : true;
-    
-    LabelActions.setAllLabelsVisibility(imageData.id, newToggleValue);
   }
 }

--- a/src/logic/actions/ImageActions.ts
+++ b/src/logic/actions/ImageActions.ts
@@ -63,7 +63,7 @@ export class ImageActions {
 
   public static toggleAllLabelsVisibility(): void {
     const imageData: ImageData = LabelsSelector.getActiveImageData();
-    const newToggleValue = imageData.allLabelsVisibilityToggle ? !imageData.allLabelsVisibilityToggle : false;
+    const newToggleValue = imageData.allLabelsVisibilityToggle !== null ? !imageData.allLabelsVisibilityToggle : false;
     
     LabelActions.setAllLabelsVisibility(imageData.id, newToggleValue);
   }

--- a/src/logic/actions/ImageActions.ts
+++ b/src/logic/actions/ImageActions.ts
@@ -153,6 +153,8 @@ export class ImageActions {
 
   public static toggleAllLabelsVisibility(): void {
     const imageData: ImageData = LabelsSelector.getActiveImageData();
-    LabelActions.toggleAllLabelsVisibility(imageData.id);
+    const newToggleValue = imageData.allLabelsVisibilityToggle ? !imageData.allLabelsVisibilityToggle : true;
+    
+    LabelActions.setAllLabelsVisibility(imageData.id, newToggleValue);
   }
 }

--- a/src/logic/actions/LabelActions.ts
+++ b/src/logic/actions/LabelActions.ts
@@ -71,6 +71,26 @@ export class LabelActions {
         store.dispatch(updateImageDataById(imageData.id, newImageData));
     }
 
+    public static toggleAllLabelsVisibility(imageId: string) {
+        const imageData: ImageData = LabelsSelector.getImageDataById(imageId);
+        const newImageData = {
+            ...imageData,
+            labelPoints: imageData.labelPoints.map((labelPoint: LabelPoint) => {
+                return LabelUtil.toggleAnnotationVisibility(labelPoint)
+            }),
+            labelRects: imageData.labelRects.map((labelRect: LabelRect) => {
+                return LabelUtil.toggleAnnotationVisibility(labelRect)
+            }),
+            labelPolygons: imageData.labelPolygons.map((labelPolygon: LabelPolygon) => {
+                return LabelUtil.toggleAnnotationVisibility(labelPolygon)
+            }),
+            labelLines: imageData.labelLines.map((labelLine: LabelLine) => {
+                return LabelUtil.toggleAnnotationVisibility(labelLine)
+            }),
+        };
+        store.dispatch(updateImageDataById(imageData.id, newImageData));
+    }
+
     public static toggleLabelVisibilityById(imageId: string, labelId: string) {
         const imageData: ImageData = LabelsSelector.getImageDataById(imageId);
         const newImageData = {

--- a/src/logic/actions/LabelActions.ts
+++ b/src/logic/actions/LabelActions.ts
@@ -71,23 +71,22 @@ export class LabelActions {
         store.dispatch(updateImageDataById(imageData.id, newImageData));
     }
 
-    public static toggleAllLabelsVisibility(imageId: string) {
+    public static setAllLabelsVisibility(imageId: string, isVisible: boolean) {
         const imageData: ImageData = LabelsSelector.getImageDataById(imageId);
-        const newToggleValue = imageData.allLabelsVisibilityToggle ? !imageData.allLabelsVisibilityToggle : true;
         const newImageData = {
             ...imageData,
-            allLabelsVisibilityToggle: newToggleValue,
+            allLabelsVisibilityToggle: isVisible,
             labelPoints: imageData.labelPoints.map((labelPoint: LabelPoint) => {
-                return LabelUtil.setAnnotationVisibility(labelPoint, newToggleValue)
+                return LabelUtil.setAnnotationVisibility(labelPoint, isVisible)
             }),
             labelRects: imageData.labelRects.map((labelRect: LabelRect) => {
-                return LabelUtil.setAnnotationVisibility(labelRect, newToggleValue)
+                return LabelUtil.setAnnotationVisibility(labelRect, isVisible)
             }),
             labelPolygons: imageData.labelPolygons.map((labelPolygon: LabelPolygon) => {
-                return LabelUtil.setAnnotationVisibility(labelPolygon, newToggleValue)
+                return LabelUtil.setAnnotationVisibility(labelPolygon, isVisible)
             }),
             labelLines: imageData.labelLines.map((labelLine: LabelLine) => {
-                return LabelUtil.setAnnotationVisibility(labelLine, newToggleValue)
+                return LabelUtil.setAnnotationVisibility(labelLine, isVisible)
             }),
         };
         

--- a/src/logic/actions/LabelActions.ts
+++ b/src/logic/actions/LabelActions.ts
@@ -73,21 +73,24 @@ export class LabelActions {
 
     public static toggleAllLabelsVisibility(imageId: string) {
         const imageData: ImageData = LabelsSelector.getImageDataById(imageId);
+        const newToggleValue = imageData.allLabelsVisibilityToggle ? !imageData.allLabelsVisibilityToggle : true;
         const newImageData = {
             ...imageData,
+            allLabelsVisibilityToggle: newToggleValue,
             labelPoints: imageData.labelPoints.map((labelPoint: LabelPoint) => {
-                return LabelUtil.toggleAnnotationVisibility(labelPoint)
+                return LabelUtil.setAnnotationVisibility(labelPoint, newToggleValue)
             }),
             labelRects: imageData.labelRects.map((labelRect: LabelRect) => {
-                return LabelUtil.toggleAnnotationVisibility(labelRect)
+                return LabelUtil.setAnnotationVisibility(labelRect, newToggleValue)
             }),
             labelPolygons: imageData.labelPolygons.map((labelPolygon: LabelPolygon) => {
-                return LabelUtil.toggleAnnotationVisibility(labelPolygon)
+                return LabelUtil.setAnnotationVisibility(labelPolygon, newToggleValue)
             }),
             labelLines: imageData.labelLines.map((labelLine: LabelLine) => {
-                return LabelUtil.toggleAnnotationVisibility(labelLine)
+                return LabelUtil.setAnnotationVisibility(labelLine, newToggleValue)
             }),
         };
+        
         store.dispatch(updateImageDataById(imageData.id, newImageData));
     }
 

--- a/src/logic/context/EditorContext.ts
+++ b/src/logic/context/EditorContext.ts
@@ -167,6 +167,13 @@ export class EditorContext extends BaseContext {
                 ImageActions.setActiveLabelOnActiveImage(9);
                 EditorActions.fullRender();
             }
-        }
+        },
+        {
+            keyCombo: ["h"],
+            action: (event: KeyboardEvent) => {
+                ImageActions.toggleAllLabelsVisibility();
+                EditorActions.fullRender();
+            }
+        },
     ];
 }

--- a/src/store/labels/types.ts
+++ b/src/store/labels/types.ts
@@ -49,6 +49,8 @@ export type ImageData = {
     labelPolygons: LabelPolygon[];
     labelNameIds: string[];
 
+    allLabelsVisibilityToggle: boolean;
+
     // YOLO
     isVisitedByYOLOObjectDetector: boolean;
 

--- a/src/utils/LabelUtil.ts
+++ b/src/utils/LabelUtil.ts
@@ -56,6 +56,13 @@ export class LabelUtil {
         }
     }
 
+    public static setAnnotationVisibility<AnnotationType extends Annotation>(annotation: AnnotationType, isVisible: boolean): AnnotationType {
+        return {
+            ...annotation,
+            isVisible
+        }
+    }
+
     public static labelNamesIdsDiff(oldLabelNames: LabelName[], newLabelNames: LabelName[]): string[] {
         return oldLabelNames.reduce((missingIds: string[], labelName: LabelName) => {
             if (!find(newLabelNames, { 'id': labelName.id })) {


### PR DESCRIPTION
### Pre-flight checklist

- [ ] Unit tests for all non-trivial changes
- [x] Tested  #locally
- [x] Updated wiki

This PR is adding a shortcut (keybind:"h") to show/hide all labels.
This should improve UX when handling large amount of annotations base on my experience and #329 