### PR TITLE
add download button for labels.txt

### DIFF
--- a/src/views/PopupView/InsertLabelNamesPopup/InsertLabelNamesPopup.tsx
+++ b/src/views/PopupView/InsertLabelNamesPopup/InsertLabelNamesPopup.tsx
@@ -45,6 +45,21 @@ const InsertLabelNamesPopup: React.FC<IProps> = (
     }) => {
     const [labelNames, setLabelNames] = useState(LabelsSelector.getLabelNames());
 
+    const handleDownloadLabels = () => {
+        if (labelNames.length === 0) {
+            alert('No labels to download');
+            return;
+        }
+
+        const fileContent = labelNames.map((label) => label.name).join('\n');
+        const blob = new Blob([fileContent], { type: 'text/plain' });
+        const link = document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = 'labels.txt';
+        link.click();
+        URL.revokeObjectURL(link.href);
+    };
+    
     const validateEmptyLabelNames = (): boolean => {
         const emptyLabelNames = filter(labelNames, (labelName: LabelName) => labelName.name === '');
         return emptyLabelNames.length === 0;
@@ -202,7 +217,7 @@ const InsertLabelNamesPopup: React.FC<IProps> = (
                     imageAlt={'download'}
                     buttonSize={{ width: 40, height: 40 }}
                     padding={25}
-                    onClick={safeAddLabelNameCallback}
+                    onClick={handleDownloadLabels}
                     externalClassName={'monochrome'}
                 />
             </div>

--- a/src/views/PopupView/InsertLabelNamesPopup/InsertLabelNamesPopup.tsx
+++ b/src/views/PopupView/InsertLabelNamesPopup/InsertLabelNamesPopup.tsx
@@ -197,6 +197,14 @@ const InsertLabelNamesPopup: React.FC<IProps> = (
                     isActive={enablePerClassColoration}
                     externalClassName={enablePerClassColoration ? '' : 'monochrome'}
                 />}
+                <ImageButton
+                    image={'ico/download.png'}
+                    imageAlt={'download'}
+                    buttonSize={{ width: 40, height: 40 }}
+                    padding={25}
+                    onClick={safeAddLabelNameCallback}
+                    externalClassName={'monochrome'}
+                />
             </div>
             <div className='RightContainer'>
                 <div className='Message'>


### PR DESCRIPTION
### Pre-flight checklist

- [x] Unit tests for all non-trivial changes
- [x] Tested locally
- [x] Updated wiki

This PR is adding a button and functionality to download all labels in a labels.txt.
This should improve UI  and https://github.com/SkalskiP/make-sense/issues/382 

Tests verified that a labels.txt file is correctly created with the expected content.
Tests ensured the download function is triggered properly.
Edge cases are handled, such as when the label list is empty.

