### PR TITLE
Add zoom and pan shortcuts. Prevent page from accidental navigation or reload

### DIFF
--- a/src/views/EditorView/EditorTopNavigationBar/EditorTopNavigationBar.tsx
+++ b/src/views/EditorView/EditorTopNavigationBar/EditorTopNavigationBar.tsx
@@ -94,7 +94,7 @@ const EditorTopNavigationBar: React.FC<IProps> = (
     };
 
     const imageDragOnClick = () => {
-        if (imageDragMode || isZoomed()) {
+        if (isZoomed() || imageDragMode) {
             updateImageDragModeStatusAction(!imageDragMode);
         }
     };

--- a/src/views/EditorView/EditorTopNavigationBar/EditorTopNavigationBar.tsx
+++ b/src/views/EditorView/EditorTopNavigationBar/EditorTopNavigationBar.tsx
@@ -1,6 +1,6 @@
 import { ContextType } from '../../../data/enums/ContextType';
 import './EditorTopNavigationBar.scss';
-import React from 'react';
+import React, { useEffect } from 'react';
 import classNames from 'classnames';
 import { AppState } from '../../../store';
 import { connect } from 'react-redux';
@@ -102,6 +102,24 @@ const EditorTopNavigationBar: React.FC<IProps> = (
         updateCrossHairVisibleStatusAction(!crossHairVisible);
     };
 
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key.toLowerCase() === 'x') {
+                ViewPortActions.zoomIn();
+            }
+
+            if (event.key.toLowerCase() === 'z') {
+                ViewPortActions.zoomOut();
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, []);
+
     const withAI = (
         (activeLabelType === LabelType.RECT && AISelector.isAISSDObjectDetectorModelLoaded()) ||
         (activeLabelType === LabelType.RECT && AISelector.isAIYOLOObjectDetectorModelLoaded()) ||
@@ -115,7 +133,7 @@ const EditorTopNavigationBar: React.FC<IProps> = (
                 {
                     getButtonWithTooltip(
                         'zoom-in',
-                        'zoom in',
+                        'zoom in (x)',
                         'ico/zoom-in.png',
                         'zoom-in',
                         false,
@@ -126,7 +144,7 @@ const EditorTopNavigationBar: React.FC<IProps> = (
                 {
                     getButtonWithTooltip(
                         'zoom-out',
-                        'zoom out',
+                        'zoom out (z)',
                         'ico/zoom-out.png',
                         'zoom-out',
                         false,

--- a/src/views/EditorView/EditorTopNavigationBar/EditorTopNavigationBar.tsx
+++ b/src/views/EditorView/EditorTopNavigationBar/EditorTopNavigationBar.tsx
@@ -89,11 +89,12 @@ const EditorTopNavigationBar: React.FC<IProps> = (
         );
     };
 
+    const isZoomed = () => {
+        return GeneralSelector.getZoom() !== ViewPointSettings.MIN_ZOOM;
+    };
+
     const imageDragOnClick = () => {
-        if (imageDragMode) {
-            updateImageDragModeStatusAction(!imageDragMode);
-        }
-        else if (GeneralSelector.getZoom() !== ViewPointSettings.MIN_ZOOM) {
+        if (imageDragMode || isZoomed()) {
             updateImageDragModeStatusAction(!imageDragMode);
         }
     };
@@ -110,6 +111,13 @@ const EditorTopNavigationBar: React.FC<IProps> = (
 
             if (event.key.toLowerCase() === 'z') {
                 ViewPortActions.zoomOut();
+            }
+
+            if (event.key.toLowerCase() === 'c') {
+                if (isZoomed() || !imageDragMode) {
+                    imageDragMode = !imageDragMode;
+                }
+                imageDragOnClick();
             }
         };
 
@@ -179,7 +187,7 @@ const EditorTopNavigationBar: React.FC<IProps> = (
                 {
                     getButtonWithTooltip(
                         'image-drag-mode',
-                        imageDragMode ? 'turn-off image drag mode' : 'turn-on image drag mode - works only when image is zoomed',
+                        imageDragMode ? 'turn-off image drag mode (c)' : 'turn-on image drag mode (c) - works only when image is zoomed',
                         'ico/hand.png',
                         'image-drag-mode',
                         imageDragMode,

--- a/src/views/EditorView/EditorView.tsx
+++ b/src/views/EditorView/EditorView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import './EditorView.scss';
 import EditorContainer from './EditorContainer/EditorContainer';
 import {PopupWindowType} from '../../data/enums/PopupWindowType';
@@ -21,6 +21,19 @@ const EditorView: React.FC<IProps> = ({activePopupType}) => {
             }
         );
     };
+
+    useEffect(() => {
+        const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+            event.preventDefault();
+            event.returnValue = '';
+        };
+
+        window.addEventListener('beforeunload', handleBeforeUnload);
+
+        return () => {
+            window.removeEventListener('beforeunload', handleBeforeUnload);
+        };
+    }, []);
 
     return (
         <div


### PR DESCRIPTION
# Summary of Changes

## Shortcut Keys Implementation

Added keyboard shortcuts to improve the user experience:

- 'z': Zoom out.
- 'x': Zoom in.
- 'c': Toggle pan mode (image drag mode).

These shortcuts provide quicker access to essential functionalities while working in the editor.

## Prevent Page Reload or Unintentional Navigation

Implemented functionality to prevent the page from closing or navigating away (forward/backward) unintentionally.
A confirmation prompt is shown when the user tries to reload the page or navigate away, helping avoid accidental loss of progress.

## Reason for Change

The addition of shortcuts simplifies user interaction, making the app more efficient.
Preventing accidental page reloads or navigation ensures that the user's work is not lost unexpectedly.

## Testing

- [x] Verified that the keyboard shortcuts ('z', 'x', 'c') work as expected and trigger the correct actions (zoom in, zoom out, toggle pan mode).
- [x] Confirmed that attempting to reload or navigate away from the page triggers a confirmation dialog to prevent accidental data loss.